### PR TITLE
#ddev-generated in files is required in next ddev release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: tests
 on:
   pull_request:
   push:
-    branches: [ master, main ]
+    branches: [ main ]
 
   schedule:
   - cron: '01 07 * * *'
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        ddev_version: [stable, edge, HEAD]
+        ddev_version: [stable, HEAD]
 #        ddev_version: [PR]
       fail-fast: false
 

--- a/install.yaml
+++ b/install.yaml
@@ -1,4 +1,4 @@
-name: addon-template
+name: ddev-laravel-queue
 
 # pre_install_actions - list of actions to run before installing the addon.
 # Examples would be removing an extraneous docker volume,
@@ -9,15 +9,13 @@ pre_install_actions:
 
 # list of files and directories listed that are copied into project .ddev directory
 project_files:
-- docker-compose.addon-template.yaml
-# - extra_files/
-# - somefile.sh
+- web-build/Dockerfile.ddev-laravel-worker
+- web-build/laravel-worker.conf
+
 
 # List of files and directories that are copied into the global .ddev directory
 global_files:
-# - commands
-# - homeadditions
+
 
 post_install_actions:
-# - chmod +x ~/.ddev/commands/web/somecommand
-# - perl -pi -e 's/oldstring/newstring/g' docker-compose.addon-template.yaml
+

--- a/web-build/laravel-worker.conf
+++ b/web-build/laravel-worker.conf
@@ -1,3 +1,4 @@
+#ddev-generated
 [program:laravel-worker]
 process_name=%(program_name)s_%(process_num)s
 command=/usr/bin/php /var/www/html/artisan queue:work --sleep=3 --tries=3


### PR DESCRIPTION
In upcoming ddev release, files that don't have #ddev-generated in them are considered customized by the user, so a second `ddev get` would fail. 