### PR TITLE
Cancel running workflows before starting new ones

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,10 @@ on:
         required: false
         default: "false"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # required for keep-alive workflow.
 permissions:
   actions: write


### PR DESCRIPTION
This PR cancels running workflows on the same push/pull branch.

This saves CPU cycles and prevents test build up when developing rapidly.

Fixes #12