### PR TITLE
bump "maintained" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tyler36/ddev-laravel-queue <!-- omit in toc -->
 
-[![tests](https://github.com/tyler36/ddev-laravel-queue/actions/workflows/tests.yml/badge.svg)](https://github.com/tyler36/ddev-laravel-queue/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2025.svg)
+[![tests](https://github.com/tyler36/ddev-laravel-queue/actions/workflows/tests.yml/badge.svg)](https://github.com/tyler36/ddev-laravel-queue/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2026.svg)
 
 - [Introduction](#introduction)
 - [Getting Started](#getting-started)


### PR DESCRIPTION
## The Issue

Currently, badge shows a "stale (as of 2025)".

## How This PR Solves The Issue

This PR bumps the badge to 2026.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

